### PR TITLE
use cl namespace instead of star suffix

### DIFF
--- a/backup-file.el
+++ b/backup-file.el
@@ -267,7 +267,7 @@
         (backup-file-git (current-buffer) "show" (car data))
         (setq replace t)
         (insert "\n"))
-      (incf i)
+      (cl-incf i)
       (goto-char (point-min)))
     (when (> (point-max) (point-min))
       (goto-char (point-max))

--- a/backup-file.el
+++ b/backup-file.el
@@ -42,11 +42,11 @@
 (defun backup-file-buffer-local-mode-keymap (mode-sym)
   (symbol-value (intern (concat (symbol-name mode-sym) "-map"))))
 
-(defun* backup-file-buffer-local-buffer-local-set-key (key action)
+(cl-defun backup-file-buffer-local-buffer-local-set-key (key action)
   (when backup-file-buffer-local-mode
     (define-key (backup-file-buffer-local-mode-keymap backup-file-buffer-local-mode)
       key action)
-    (return-from backup-file-buffer-local-buffer-local-set-key))
+    (cl-return-from backup-file-buffer-local-buffer-local-set-key))
   (let* ((mode-name-loc (cl-gensym "-blm")))
     (eval `(define-minor-mode ,mode-name-loc nil nil nil (make-sparse-keymap)))
     (setq backup-file-buffer-local-mode mode-name-loc)


### PR DESCRIPTION
These changes are an attempt to address #1, which work for me on Linux, MacOS and Termux.