### PR TITLE
Remove cl usage

### DIFF
--- a/backup-file.el
+++ b/backup-file.el
@@ -42,11 +42,11 @@
 (defun backup-file-buffer-local-mode-keymap (mode-sym)
   (symbol-value (intern (concat (symbol-name mode-sym) "-map"))))
 
-(cl-defun backup-file-buffer-local-buffer-local-set-key (key action)
+(defun backup-file-buffer-local-buffer-local-set-key (key action)
   (if backup-file-buffer-local-mode
     (define-key (backup-file-buffer-local-mode-keymap backup-file-buffer-local-mode)
       key action)
-    (let* ((mode-name-loc (cl-gensym "-blm")))
+    (let ((mode-name-loc (cl-gensym "-blm")))
       (eval `(define-minor-mode ,mode-name-loc nil nil nil (make-sparse-keymap)))
       (setq backup-file-buffer-local-mode mode-name-loc)
       (funcall mode-name-loc 1)

--- a/backup-file.el
+++ b/backup-file.el
@@ -43,15 +43,14 @@
   (symbol-value (intern (concat (symbol-name mode-sym) "-map"))))
 
 (cl-defun backup-file-buffer-local-buffer-local-set-key (key action)
-  (when backup-file-buffer-local-mode
+  (if backup-file-buffer-local-mode
     (define-key (backup-file-buffer-local-mode-keymap backup-file-buffer-local-mode)
       key action)
-    (cl-return-from backup-file-buffer-local-buffer-local-set-key))
-  (let* ((mode-name-loc (cl-gensym "-blm")))
-    (eval `(define-minor-mode ,mode-name-loc nil nil nil (make-sparse-keymap)))
-    (setq backup-file-buffer-local-mode mode-name-loc)
-    (funcall mode-name-loc 1)
-    (define-key (backup-file-buffer-local-mode-keymap mode-name-loc) key action)))
+    (let* ((mode-name-loc (cl-gensym "-blm")))
+      (eval `(define-minor-mode ,mode-name-loc nil nil nil (make-sparse-keymap)))
+      (setq backup-file-buffer-local-mode mode-name-loc)
+      (funcall mode-name-loc 1)
+      (define-key (backup-file-buffer-local-mode-keymap mode-name-loc) key action))))
 
 (defcustom backup-file-location (expand-file-name "~/.backups") "Where to store backup repo" :group 'backup-file :type 'string)
 


### PR DESCRIPTION
I was having trouble using the package after upgrading to v27 and noticed that it was related to the common lisp package usage.

This PR is an attempt to remove the dependency on `cl`. Please let me know if there issues or missing behavior. 

Any feedback is welcome.